### PR TITLE
Fix Firefox and IE rendering issue

### DIFF
--- a/jquery/jquery-barcode.js
+++ b/jquery/jquery-barcode.js
@@ -1232,6 +1232,10 @@
           fontSize = intval(settings.fontSize);
           height += intval(settings.marginHRI) + fontSize;
         }
+        
+        //correct any hash (#) chars in color settings to prevent breakage in Firefox/IE rendering
+        settings.bgColor = settings.bgColor.replace('#', '%23' );
+        settings.color = settings.color.replace( '#', '%23');
 
         // svg header
         svg = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="' + width + '" height="' + height + '">';


### PR DESCRIPTION
"#" in color settings for svg must be encoded with %23 otherwise firefox and IE svg display breaks.

Fixes #11