### PR TITLE
fix/barcode-skewed-zoom

### DIFF
--- a/jquery/jquery-barcode.js
+++ b/jquery/jquery-barcode.js
@@ -1096,12 +1096,12 @@
     }
     return le;
   }
-  
+
   // return a byte string from rgb values
   function lecCRgb(r, g, b) {
     return String.fromCharCode(b) + String.fromCharCode(g) + String.fromCharCode(r);
   }
-  
+
   // return a byte string from a hex string color
   function lecCHexColor(hex) {
     var g, r,
@@ -1112,7 +1112,7 @@
     r = v >> 8;
     return (lecCRgb(r, g, b));
   }
-  
+
   function hexToRGB(hex) {
     var g, r,
       v = parseInt("0x" + hex.substr(1), 16),
@@ -1122,12 +1122,12 @@
     r = v >> 8;
     return ({r: r, g: g, b: b});
   }
-  
+
   // test if a string is a hexa string color (like #FF0000)
   function isHexColor(value) {
     return value.match(/#[0-91-F]/gi);
   }
-  
+
   // encode data in base64
   function base64Encode(value) {
     var c1, c2, c3, b1, b2, b3, b4,
@@ -1151,7 +1151,7 @@
     }
     return r;
   }
-  
+
   // convert a bit string to an array of array of bit char
   function bitStringTo2DArray(digit) {
     var i,
@@ -1162,7 +1162,7 @@
     }
     return d;
   }
-  
+
   // clear jQuery Target
   function resize($container, w) {
     $container
@@ -1375,39 +1375,39 @@
       h = intval(settings.barHeight);
     digitToBmpRenderer($container, settings, bitStringTo2DArray(digit), hri, w, h);
   };
-  
+
   // bmp 2D barcode renderer
   renderer.bmp2 = function ($container, settings, digit, hri) {
     var s = intval(settings.moduleSize);
     digitToBmpRenderer($container, settings, digit, hri, s, s);
   };
-  
+
   // css 1D barcode renderer
   renderer.css = function ($container, settings, digit, hri) {
     var w = intval(settings.barWidth),
       h = intval(settings.barHeight);
     digitToCssRenderer($container, settings, bitStringTo2DArray(digit), hri, w, h);
   };
-  
+
   // css 2D barcode renderer
   renderer.css2 = function ($container, settings, digit, hri) {
     var s = intval(settings.moduleSize);
     digitToCssRenderer($container, settings, digit, hri, s, s);
   };
-  
+
   // svg 1D barcode renderer
   renderer.svg = function ($container, settings, digit, hri) {
     var w = intval(settings.barWidth),
       h = intval(settings.barHeight);
     digitToSvgRenderer($container, settings, bitStringTo2DArray(digit), hri, w, h);
   };
-  
+
   // svg 2D barcode renderer
   renderer.svg2 = function ($container, settings, digit, hri) {
     var s = intval(settings.moduleSize);
     digitToSvgRenderer($container, settings, digit, hri, s, s);
   };
-  
+
   // canvas 1D barcode renderer
   renderer.canvas = function ($container, settings, digit, hri) {
     var w  = intval(settings.barWidth),
@@ -1416,7 +1416,7 @@
       y = intval(settings.posY);
     digitToCanvasRenderer($container, settings, bitStringTo2DArray(digit), hri, x, y, w, h);
   };
-  
+
   // canvas 2D barcode renderer
   renderer.canvas2 = function ($container, settings, digit, hri) {
     var s = intval(settings.moduleSize),

--- a/jquery/jquery-barcode.js
+++ b/jquery/jquery-barcode.js
@@ -1180,7 +1180,7 @@
       .css("flex-flow", "row wrap")
       .css("justify-content", "space-around");
     return $container;
-  },
+  }
 
   // * * * * * * * * * * * * * * * * * * * * * *
   // Raw Renderer functions

--- a/jquery/jquery-barcode.js
+++ b/jquery/jquery-barcode.js
@@ -1173,6 +1173,15 @@
     return $container;
   }
 
+  // apply antialiasing for CSS rendering only
+  function antialiasing($container){
+    $container
+      .css("display", "flex")
+      .css("flex-flow", "row wrap")
+      .css("justify-content", "space-around");
+    return $container;
+  },
+
   // * * * * * * * * * * * * * * * * * * * * * *
   // Raw Renderer functions
   // * * * * * * * * * * * * * * * * * * * * * *
@@ -1262,6 +1271,7 @@
     if (settings.showHRI) {
       content += "<div style=\"clear:both; width: 100%; background-color: " + settings.bgColor + "; color: " + settings.color + "; text-align: center; font-size: " + settings.fontSize + "px; margin-top: " + settings.marginHRI + "px;\">" + hri + "</div>";
     }
+    antialiasing($container);
     resize($container, mw * columns).html(content);
   }
 
@@ -1279,7 +1289,7 @@
     }
 
     // svg header
-    svg = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="' + width + '" height="' + height + '">';
+    svg = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="' + width + '" height="' + height + '" shape-rendering="crispEdges">';
 
     // background
     svg += '<rect width="' +  width + '" height="' + height + '" x="0" y="0" fill="' + settings.bgColor + '" />';

--- a/prototype/prototype-barcode.js
+++ b/prototype/prototype-barcode.js
@@ -1,14 +1,14 @@
 /*!
  *  BarCode Coder Library (BCC Library)
  *  BCCL Version 2.0
- *    
- *  Porting : Prototype barcode plugin 
+ *
+ *  Porting : Prototype barcode plugin
  *  Version : 2.0.3
- *   
+ *
  *  Date    : 2013-01-06
  *  Author  : DEMONTE Jean-Baptiste <jbdemonte@gmail.com>
  *            HOUREZ Jonathan
- * 
+ *
  *  Web site: http://barcode-coder.com/
  *  dual licence :  http://www.cecill.info/licences/Licence_CeCILL_V2-fr.html
  *                  http://www.gnu.org/licenses/gpl.html
@@ -60,14 +60,14 @@ var Barcode = {
       code = this.compute(code, crc, type);
       if (code == "") return("");
       result = "";
-      
+
       var i, j;
       if (type == "int25") {
         // Interleaved 2 of 5
-        
+
         // start
         result += "1010";
-        
+
         // digits + CRC
         var c1, c2;
         for(i=0; i<code.length / 2; i++){
@@ -83,13 +83,13 @@ var Barcode = {
         // stop
         result += "1101";
       } else if (type == "std25") {
-        // Standard 2 of 5 is a numeric-only barcode that has been in use a long time. 
+        // Standard 2 of 5 is a numeric-only barcode that has been in use a long time.
         // Unlike Interleaved 2 of 5, all of the information is encoded in the bars; the spaces are fixed width and are used only to separate the bars.
         // The code is self-checking and does not include a checksum.
-        
+
         // start
         result += "11011010";
-        
+
         // digits + CRC
         var c;
         for(i=0; i<code.length; i++){
@@ -108,10 +108,10 @@ var Barcode = {
   },
   ean: {
     encoding: [ ["0001101", "0100111", "1110010"],
-                ["0011001", "0110011", "1100110"], 
+                ["0011001", "0110011", "1100110"],
                 ["0010011", "0011011", "1101100"],
-                ["0111101", "0100001", "1000010"], 
-                ["0100011", "0011101", "1011100"], 
+                ["0111101", "0100001", "1000010"],
+                ["0100011", "0011101", "1011100"],
                 ["0110001", "0111001", "1001110"],
                 ["0101111", "0000101", "1010000"],
                 ["0111011", "0010001", "1000100"],
@@ -131,43 +131,43 @@ var Barcode = {
       }
       // get checksum
       code = this.compute(code, type);
-      
+
       // process analyse
       var result = "101"; // start
-      
+
       if (type == "ean8"){
 
         // process left part
         for(var i=0; i<4; i++){
           result += this.encoding[Barcode.intval(code.charAt(i))][0];
         }
-            
+
         // center guard bars
         result += "01010";
-            
+
         // process right part
         for(var i=4; i<8; i++){
           result += this.encoding[Barcode.intval(code.charAt(i))][2];
         }
-            
+
       } else { // ean13
         // extract first digit and get sequence
         var seq = this.first[ Barcode.intval(code.charAt(0)) ];
-        
+
         // process left part
         for(var i=1; i<7; i++){
           result += this.encoding[Barcode.intval(code.charAt(i))][ Barcode.intval(seq.charAt(i-1)) ];
         }
-        
+
         // center guard bars
         result += "01010";
-            
+
         // process right part
         for(var i=7; i<13; i++){
           result += this.encoding[Barcode.intval(code.charAt(i))][ 2 ];
         }
       } // ean13
-      
+
       result += "101"; // stop
       return(result);
     },
@@ -218,7 +218,7 @@ var Barcode = {
       return(code);
     },
     computeMod10:function(code){
-      var i, 
+      var i,
       toPart1 = code.length % 2;
       var n1 = 0, sum = 0;
       for(i=0; i<code.length; i++){
@@ -247,22 +247,22 @@ var Barcode = {
       var table = "0123456789";
       var index = 0;
       var result = "";
-      
+
       code = this.compute(code, false);
-      
+
       // start
       result = "110";
-      
+
       // digits
       for(i=0; i<code.length; i++){
         index = table.indexOf( code.charAt(i) );
         if (index < 0) return("");
         result += this.encoding[ index ];
       }
-      
+
       // stop
       result += "1001";
-      
+
       return(result);
     }
   },
@@ -273,17 +273,17 @@ var Barcode = {
     getDigit: function(code){
       var table = "0123456789-";
       var i, index, result = "", intercharacter = '0'
-      
+
       // start
       result = "1011001" + intercharacter;
-      
+
       // digits
       for(i=0; i<code.length; i++){
         index = table.indexOf( code.charAt(i) );
         if (index < 0) return("");
         result += this.encoding[ index ] + intercharacter;
       }
-      
+
       // checksum
       var weightC    = 0,
       weightSumC = 0,
@@ -292,28 +292,28 @@ var Barcode = {
       for(i=code.length-1; i>=0; i--){
         weightC = weightC == 10 ? 1 : weightC + 1;
         weightK = weightK == 10 ? 1 : weightK + 1;
-        
+
         index = table.indexOf( code.charAt(i) );
-        
+
         weightSumC += weightC * index;
         weightSumK += weightK * index;
       }
-      
+
       var c = weightSumC % 11;
       weightSumK += c;
       var k = weightSumK % 11;
-      
+
       result += this.encoding[c] + intercharacter;
-      
+
       if (code.length >= 10){
         result += this.encoding[k] + intercharacter;
       }
-      
+
       // stop
       result  += "1011001";
-      
+
       return(result);
-    }   
+    }
   },
   code39: {
     encoding:["101001101101", "110100101011", "101100101011", "110110010101",
@@ -330,12 +330,12 @@ var Barcode = {
     getDigit: function(code){
       var table = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%*";
       var i, index, result="", intercharacter='0';
-      
+
       if (code.indexOf('*') >= 0) return("");
-      
+
       // Add Start and Stop charactere : *
       code = ("*" + code + "*").toUpperCase();
-      
+
       for(i=0; i<code.length; i++){
         index = table.indexOf( code.charAt(i) );
         if (index < 0) return("");
@@ -361,14 +361,14 @@ var Barcode = {
     getDigit: function(code, crc){
       var table = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%____*", // _ => ($), (%), (/) et (+)
       c, result = "";
-      
+
       if (code.indexOf('*') >= 0) return("");
-      
+
       code = code.toUpperCase();
-      
+
       // start :  *
       result  += this.encoding[47];
-      
+
       // digits
       for(i=0; i<code.length; i++){
         c = code.charAt(i);
@@ -376,7 +376,7 @@ var Barcode = {
         if ( (c == '_') || (index < 0) ) return("");
         result += this.encoding[ index ];
       }
-      
+
       // checksum
       if (crc){
         var weightC    = 0,
@@ -386,24 +386,24 @@ var Barcode = {
         for(i=code.length-1; i>=0; i--){
           weightC = weightC == 20 ? 1 : weightC + 1;
           weightK = weightK == 15 ? 1 : weightK + 1;
-          
+
           index = table.indexOf( code.charAt(i) );
-          
+
           weightSumC += weightC * index;
           weightSumK += weightK * index;
         }
-        
+
         var c = weightSumC % 47;
         weightSumK += c;
         var k = weightSumK % 47;
-        
+
         result += this.encoding[c];
         result += this.encoding[k];
       }
-      
+
       // stop : *
       result  += this.encoding[47];
-      
+
       // Terminaison bar
       result  += '1';
       return(result);
@@ -445,12 +445,12 @@ var Barcode = {
       var i = 0;
       var j = 0;
       var value = 0;
-      
+
       // check each characters
       for(i=0; i<code.length; i++){
         if (tableB.indexOf(code.charAt(i)) == -1) return("");
       }
-      
+
       // check firsts characters : start with C table only if enought numeric
       var tableCActivated = code.length > 1;
       var c = '';
@@ -458,22 +458,22 @@ var Barcode = {
       c = code.charAt(i);
         tableCActivated &= c >= '0' && c <= '9';
       }
-      
+
       sum = tableCActivated ? 105 : 104;
-      
-      // start : [105] : C table or [104] : B table 
+
+      // start : [105] : C table or [104] : B table
       result = this.encoding[ sum ];
-      
+
       i = 0;
       while( i < code.length ){
         if (! tableCActivated){
           j = 0;
           // check next character to activate C table if interresting
           while ( (i + j < code.length) && (code.charAt(i+j) >= '0') && (code.charAt(i+j) <= '9') ) j++;
-          
+
           // 6 min everywhere or 4 mini at the end
           tableCActivated = (j > 5) || ((i + j - 1 == code.length) && (j > 3));
-          
+
           if ( tableCActivated ){
           result += this.encoding[ 99 ]; // C table
           sum += ++isum * 99;
@@ -484,7 +484,7 @@ var Barcode = {
           result += this.encoding[ 100 ]; // B table
           sum += ++isum * 100;
         }
-        
+
         if ( tableCActivated ) {
           value = Barcode.intval(code.charAt(i) + code.charAt(i+1)); // Add two characters (numeric)
           i += 2;
@@ -495,16 +495,16 @@ var Barcode = {
         result  += this.encoding[ value ];
         sum += ++isum * value;
       }
-      
+
       // Add CRC
       result  += this.encoding[ sum % 103 ];
-      
+
       // Stop
       result += this.encoding[106];
-      
+
       // Termination bar
       result += "11";
-      
+
       return(result);
     }
   },
@@ -517,16 +517,16 @@ var Barcode = {
     getDigit: function(code){
       var table = "0123456789-$:/.+";
       var i, index, result="", intercharacter = '0';
-      
+
       // add start : A->D : arbitrary choose A
       result += this.encoding[16] + intercharacter;
-      
+
       for(i=0; i<code.length; i++){
         index = table.indexOf( code.charAt(i) );
         if (index < 0) return("");
         result += this.encoding[ index ] + intercharacter;
       }
-      
+
       // add stop : A->D : arbitrary choose A
       result += this.encoding[16];
       return(result);
@@ -540,7 +540,7 @@ var Barcode = {
                         32, 36, 40, 44, 48, 52, 64, 72, 80, 88, 96, 104, 120, 132, 144,
                         18, 32, 26, 36, 36, 48],
     dataCWCount:      [ 3, 5, 8, 12,  18,  22,  30,  36,  // Number of data codewords for the datamatrix
-                        44, 62, 86, 114, 144, 174, 204, 280, 368, 456, 576, 696, 816, 1050, 
+                        44, 62, 86, 114, 144, 174, 204, 280, 368, 456, 576, 696, 816, 1050,
                         1304, 1558, 5, 10, 16, 22, 32, 49],
     solomonCWCount:   [ 5, 7, 10, 12, 14, 18, 20, 24, 28, // Number of Reed-Solomon codewords for the datamatrix
                         36, 42, 48, 56, 68, 84, 112, 144, 192, 224, 272, 336, 408, 496, 620,
@@ -561,40 +561,40 @@ var Barcode = {
                         1, 1, 1, 1, 1, 1, 2, 2, 4, 4, 4, 4, 6, 6, 8, 8,
                         1, 1, 1, 1, 1, 1],
     logTab:           [ -255, 255, 1, 240, 2, 225, 241, 53, 3,  // Table of log for the Galois field
-                        38, 226, 133, 242, 43, 54, 210, 4, 195, 39, 114, 227, 106, 134, 28, 
-                        243, 140, 44, 23, 55, 118, 211, 234, 5, 219, 196, 96, 40, 222, 115, 
-                        103, 228, 78, 107, 125, 135, 8, 29, 162, 244, 186, 141, 180, 45, 99, 
-                        24, 49, 56, 13, 119, 153, 212, 199, 235, 91, 6, 76, 220, 217, 197, 
-                        11, 97, 184, 41, 36, 223, 253, 116, 138, 104, 193, 229, 86, 79, 171, 
-                        108, 165, 126, 145, 136, 34, 9, 74, 30, 32, 163, 84, 245, 173, 187, 
-                        204, 142, 81, 181, 190, 46, 88, 100, 159, 25, 231, 50, 207, 57, 147, 
-                        14, 67, 120, 128, 154, 248, 213, 167, 200, 63, 236, 110, 92, 176, 7, 
-                        161, 77, 124, 221, 102, 218, 95, 198, 90, 12, 152, 98, 48, 185, 179, 
-                        42, 209, 37, 132, 224, 52, 254, 239, 117, 233, 139, 22, 105, 27, 194, 
-                        113, 230, 206, 87, 158, 80, 189, 172, 203, 109, 175, 166, 62, 127, 
-                        247, 146, 66, 137, 192, 35, 252, 10, 183, 75, 216, 31, 83, 33, 73, 
-                        164, 144, 85, 170, 246, 65, 174, 61, 188, 202, 205, 157, 143, 169, 82, 
-                        72, 182, 215, 191, 251, 47, 178, 89, 151, 101, 94, 160, 123, 26, 112, 
-                        232, 21, 51, 238, 208, 131, 58, 69, 148, 18, 15, 16, 68, 17, 121, 149, 
-                        129, 19, 155, 59, 249, 70, 214, 250, 168, 71, 201, 156, 64, 60, 237, 
+                        38, 226, 133, 242, 43, 54, 210, 4, 195, 39, 114, 227, 106, 134, 28,
+                        243, 140, 44, 23, 55, 118, 211, 234, 5, 219, 196, 96, 40, 222, 115,
+                        103, 228, 78, 107, 125, 135, 8, 29, 162, 244, 186, 141, 180, 45, 99,
+                        24, 49, 56, 13, 119, 153, 212, 199, 235, 91, 6, 76, 220, 217, 197,
+                        11, 97, 184, 41, 36, 223, 253, 116, 138, 104, 193, 229, 86, 79, 171,
+                        108, 165, 126, 145, 136, 34, 9, 74, 30, 32, 163, 84, 245, 173, 187,
+                        204, 142, 81, 181, 190, 46, 88, 100, 159, 25, 231, 50, 207, 57, 147,
+                        14, 67, 120, 128, 154, 248, 213, 167, 200, 63, 236, 110, 92, 176, 7,
+                        161, 77, 124, 221, 102, 218, 95, 198, 90, 12, 152, 98, 48, 185, 179,
+                        42, 209, 37, 132, 224, 52, 254, 239, 117, 233, 139, 22, 105, 27, 194,
+                        113, 230, 206, 87, 158, 80, 189, 172, 203, 109, 175, 166, 62, 127,
+                        247, 146, 66, 137, 192, 35, 252, 10, 183, 75, 216, 31, 83, 33, 73,
+                        164, 144, 85, 170, 246, 65, 174, 61, 188, 202, 205, 157, 143, 169, 82,
+                        72, 182, 215, 191, 251, 47, 178, 89, 151, 101, 94, 160, 123, 26, 112,
+                        232, 21, 51, 238, 208, 131, 58, 69, 148, 18, 15, 16, 68, 17, 121, 149,
+                        129, 19, 155, 59, 249, 70, 214, 250, 168, 71, 201, 156, 64, 60, 237,
                         130, 111, 20, 93, 122, 177, 150],
     aLogTab:          [ 1, 2, 4, 8, 16, 32, 64, 128, 45, 90, // Table of aLog for the Galois field
-                        180, 69, 138, 57, 114, 228, 229, 231, 227, 235, 251, 219, 155, 27, 54, 
-                        108, 216, 157, 23, 46, 92, 184, 93, 186, 89, 178, 73, 146, 9, 18, 36, 
-                        72, 144, 13, 26, 52, 104, 208, 141, 55, 110, 220, 149, 7, 14, 28, 56, 
-                        112, 224, 237, 247, 195, 171, 123, 246, 193, 175, 115, 230, 225, 239, 
-                        243, 203, 187, 91, 182, 65, 130, 41, 82, 164, 101, 202, 185, 95, 190, 
-                        81, 162, 105, 210, 137, 63, 126, 252, 213, 135, 35, 70, 140, 53, 106, 
-                        212, 133, 39, 78, 156, 21, 42, 84, 168, 125, 250, 217, 159, 19, 38, 76, 
-                        152, 29, 58, 116, 232, 253, 215, 131, 43, 86, 172, 117, 234, 249, 223, 
-                        147, 11, 22, 44, 88, 176, 77, 154, 25, 50, 100, 200, 189, 87, 174, 113, 
-                        226, 233, 255, 211, 139, 59, 118, 236, 245, 199, 163, 107, 214, 129, 
-                        47, 94, 188, 85, 170, 121, 242, 201, 191, 83, 166, 97, 194, 169, 127, 
-                        254, 209, 143, 51, 102, 204, 181, 71, 142, 49, 98, 196, 165, 103, 206, 
-                        177, 79, 158, 17, 34, 68, 136, 61, 122, 244, 197, 167, 99, 198, 161, 
-                        111, 222, 145, 15, 30, 60, 120, 240, 205, 183, 67, 134, 33, 66, 132, 
-                        37, 74, 148, 5, 10, 20, 40, 80, 160, 109, 218, 153, 31, 62, 124, 248, 
-                        221, 151, 3, 6, 12, 24, 48, 96, 192, 173, 119, 238, 241, 207, 179, 75, 
+                        180, 69, 138, 57, 114, 228, 229, 231, 227, 235, 251, 219, 155, 27, 54,
+                        108, 216, 157, 23, 46, 92, 184, 93, 186, 89, 178, 73, 146, 9, 18, 36,
+                        72, 144, 13, 26, 52, 104, 208, 141, 55, 110, 220, 149, 7, 14, 28, 56,
+                        112, 224, 237, 247, 195, 171, 123, 246, 193, 175, 115, 230, 225, 239,
+                        243, 203, 187, 91, 182, 65, 130, 41, 82, 164, 101, 202, 185, 95, 190,
+                        81, 162, 105, 210, 137, 63, 126, 252, 213, 135, 35, 70, 140, 53, 106,
+                        212, 133, 39, 78, 156, 21, 42, 84, 168, 125, 250, 217, 159, 19, 38, 76,
+                        152, 29, 58, 116, 232, 253, 215, 131, 43, 86, 172, 117, 234, 249, 223,
+                        147, 11, 22, 44, 88, 176, 77, 154, 25, 50, 100, 200, 189, 87, 174, 113,
+                        226, 233, 255, 211, 139, 59, 118, 236, 245, 199, 163, 107, 214, 129,
+                        47, 94, 188, 85, 170, 121, 242, 201, 191, 83, 166, 97, 194, 169, 127,
+                        254, 209, 143, 51, 102, 204, 181, 71, 142, 49, 98, 196, 165, 103, 206,
+                        177, 79, 158, 17, 34, 68, 136, 61, 122, 244, 197, 167, 99, 198, 161,
+                        111, 222, 145, 15, 30, 60, 120, 240, 205, 183, 67, 134, 33, 66, 132,
+                        37, 74, 148, 5, 10, 20, 40, 80, 160, 109, 218, 153, 31, 62, 124, 248,
+                        221, 151, 3, 6, 12, 24, 48, 96, 192, 173, 119, 238, 241, 207, 179, 75,
                         150, 1],
     champGaloisMult: function(a, b){  // MULTIPLICATION IN GALOIS FIELD GF(2^8)
       if(!a || !b) return 0;
@@ -611,10 +611,10 @@ var Barcode = {
     selectIndex: function(dataCodeWordsCount, rectangular){ // CHOOSE THE GOOD INDEX FOR TABLES
       if ((dataCodeWordsCount<1 || dataCodeWordsCount>1558) && !rectangular) return -1;
       if ((dataCodeWordsCount<1 || dataCodeWordsCount>49) && rectangular)  return -1;
-      
+
       var n = 0;
       if ( rectangular ) n = 24;
-      
+
       while (this.dataCWCount[n] < dataCodeWordsCount) n++;
       return n;
     },
@@ -623,7 +623,7 @@ var Barcode = {
       var n = 0, i, c;
       for (i=0; i<text.length; i++){
         c = text.charCodeAt(i);
-        if (c > 127) {  
+        if (c > 127) {
           dataCodeWords[n] = 235;
           c = c - 127;
           n++;
@@ -631,13 +631,13 @@ var Barcode = {
           c = ((c - 48) * 10) + ((text.charCodeAt(i+1))-48);
           c += 130;
           i++;
-        } else c++; 
+        } else c++;
         dataCodeWords[n] = c;
         n++;
       }
       return dataCodeWords;
     },
-    addPadCW: function(tab, from, to){    
+    addPadCW: function(tab, from, to){
       if (from >= to) return ;
       tab[from] = 129;
       var r, i;
@@ -649,32 +649,32 @@ var Barcode = {
     calculSolFactorTable: function(solomonCWCount){ // CALCULATE THE REED SOLOMON FACTORS
       var g = new Array();
       var i, j;
-      
+
       for (i=0; i<=solomonCWCount; i++) g[i] = 1;
-      
+
       for(i = 1; i <= solomonCWCount; i++) {
         for(j = i - 1; j >= 0; j--) {
-          g[j] = this.champGaloisDoub(g[j], i);  
+          g[j] = this.champGaloisDoub(g[j], i);
           if(j > 0) g[j] = this.champGaloisSum(g[j], g[j-1]);
         }
       }
       return g;
     },
     addReedSolomonCW: function(nSolomonCW, coeffTab, nDataCW, dataTab, blocks){ // Add the Reed Solomon codewords
-      var temp = 0;    
+      var temp = 0;
       var errorBlocks = nSolomonCW / blocks;
       var correctionCW = new Array();
-      
+
       var i,j,k;
-      for(k = 0; k < blocks; k++) {      
+      for(k = 0; k < blocks; k++) {
         for (i=0; i<errorBlocks; i++) correctionCW[i] = 0;
-        
-        for (i=k; i<nDataCW; i=i+blocks){    
+
+        for (i=k; i<nDataCW; i=i+blocks){
           temp = this.champGaloisSum(dataTab[i], correctionCW[errorBlocks-1]);
-          for (j=errorBlocks-1; j>=0; j--){     
+          for (j=errorBlocks-1; j>=0; j--){
             if ( !temp ) {
               correctionCW[j] = 0;
-            } else { 
+            } else {
               correctionCW[j] = this.champGaloisMult(temp, coeffTab[j]);
             }
             if (j>0) correctionCW[j] = this.champGaloisSum(correctionCW[j-1], correctionCW[j]);
@@ -700,11 +700,11 @@ var Barcode = {
       var chr = 0; // Place of the 8st bit from the first character to [4][0]
       var row = 4;
       var col = 0;
-      
+
       do {
         // Check for a special case of corner
         if((row == totalRows) && (col == 0)){
-          this.patternShapeSpecial1(datamatrix, assigned, codeWordsBits[chr], totalRows, totalCols);  
+          this.patternShapeSpecial1(datamatrix, assigned, codeWordsBits[chr], totalRows, totalCols);
           chr++;
         } else if((etape<3) && (row == totalRows-2) && (col == 0) && (totalCols%4 != 0)){
           this.patternShapeSpecial2(datamatrix, assigned, codeWordsBits[chr], totalRows, totalCols);
@@ -717,7 +717,7 @@ var Barcode = {
           this.patternShapeSpecial4(datamatrix, assigned, codeWordsBits[chr], totalRows, totalCols);
           chr++;
         }
-        
+
         // Go up and right in the datamatrix
         do {
           if((row < totalRows) && (col >= 0) && (assigned[row][col]!=1)) {
@@ -725,11 +725,11 @@ var Barcode = {
             chr++;
           }
           row -= 2;
-          col += 2;      
+          col += 2;
         } while ((row >= 0) && (col < totalCols));
         row += 1;
         col += 3;
-        
+
         // Go down and left in the datamatrix
         do {
           if((row >= 0) && (col < totalCols) && (assigned[row][col]!=1)){
@@ -752,7 +752,7 @@ var Barcode = {
       this.placeBitInDatamatrix(datamatrix, assigned, bits[5], row, col-2, totalRows, totalCols);
       this.placeBitInDatamatrix(datamatrix, assigned, bits[6], row, col-1, totalRows, totalCols);
       this.placeBitInDatamatrix(datamatrix, assigned, bits[7], row,  col, totalRows, totalCols);
-    },  
+    },
     patternShapeSpecial1: function(datamatrix, assigned, bits, totalRows, totalCols ){
       this.placeBitInDatamatrix(datamatrix, assigned, bits[0], totalRows-1,  0, totalRows, totalCols);
       this.placeBitInDatamatrix(datamatrix, assigned, bits[1], totalRows-1,  1, totalRows, totalCols);
@@ -772,7 +772,7 @@ var Barcode = {
       this.placeBitInDatamatrix(datamatrix, assigned, bits[5], 0, totalCols-2, totalRows, totalCols);
       this.placeBitInDatamatrix(datamatrix, assigned, bits[6], 0, totalCols-1, totalRows, totalCols);
       this.placeBitInDatamatrix(datamatrix, assigned, bits[7], 1, totalCols-1, totalRows, totalCols);
-    },  
+    },
     patternShapeSpecial3: function(datamatrix, assigned, bits, totalRows, totalCols ){
       this.placeBitInDatamatrix(datamatrix, assigned, bits[0], totalRows-3,  0, totalRows, totalCols);
       this.placeBitInDatamatrix(datamatrix, assigned, bits[1], totalRows-2,  0, totalRows, totalCols);
@@ -810,7 +810,7 @@ var Barcode = {
     addFinderPattern: function(datamatrix, rowsRegion, colsRegion, rowsRegionCW, colsRegionCW){ // Add the finder pattern
       var totalRowsCW = (rowsRegionCW+2) * rowsRegion;
       var totalColsCW = (colsRegionCW+2) * colsRegion;
-      
+
       var datamatrixTemp = new Array();
       datamatrixTemp[0] = new Array();
       for (var j=0; j<totalColsCW+2; j++){
@@ -824,10 +824,10 @@ var Barcode = {
           if (i%(rowsRegionCW+2) == 0){
             if (j%2 == 0){
               datamatrixTemp[i+1][j+1] = 1;
-            } else { 
+            } else {
               datamatrixTemp[i+1][j+1] = 0;
             }
-          } else if (i%(rowsRegionCW+2) == rowsRegionCW+1){ 
+          } else if (i%(rowsRegionCW+2) == rowsRegionCW+1){
             datamatrixTemp[i+1][j+1] = 1;
           } else if (j%(colsRegionCW+2) == colsRegionCW+1){
             if (i%2 == 0){
@@ -835,7 +835,7 @@ var Barcode = {
             } else {
               datamatrixTemp[i+1][j+1] = 1;
             }
-          } else if (j%(colsRegionCW+2) == 0){ 
+          } else if (j%(colsRegionCW+2) == 0){
             datamatrixTemp[i+1][j+1] = 1;
           } else{
             datamatrixTemp[i+1][j+1] = 0;
@@ -854,8 +854,8 @@ var Barcode = {
       var dataCWCount = dataCodeWords.length;
       var index = this.selectIndex(dataCWCount, rectangular); // Select the index for the data tables
       var totalDataCWCount = this.dataCWCount[index]; // Number of data CW
-      var solomonCWCount = this.solomonCWCount[index]; // Number of Reed Solomon CW 
-      var totalCWCount = totalDataCWCount + solomonCWCount; // Number of CW      
+      var solomonCWCount = this.solomonCWCount[index]; // Number of Reed Solomon CW
+      var totalCWCount = totalDataCWCount + solomonCWCount; // Number of CW
       var rowsTotal = this.lengthRows[index]; // Size of symbol
       var colsTotal = this.lengthCols[index];
       var rowsRegion = this.regionRows[index]; // Number of region
@@ -866,26 +866,26 @@ var Barcode = {
       var colsLengthMatrice = colsTotal-2*colsRegion;
       var blocks = this.interleavedBlocks[index];  // Number of Reed Solomon blocks
       var errorBlocks = (solomonCWCount / blocks);
-      
+
       this.addPadCW(dataCodeWords, dataCWCount, totalDataCWCount); // Add codewords pads
-      
+
       var g = this.calculSolFactorTable(errorBlocks); // Calculate correction coefficients
-      
+
       this.addReedSolomonCW(solomonCWCount, g, totalDataCWCount, dataCodeWords, blocks); // Add Reed Solomon codewords
-      
+
       var codeWordsBits = new Array(); // Calculte bits from codewords
       for (var i=0; i<totalCWCount; i++){
         codeWordsBits[i] = this.getBits(dataCodeWords[i]);
       }
-      
+
       var datamatrix = new Array(); // Put data in the matrix
       var assigned = new Array();
-      
+
       for (var i=0; i<colsLengthMatrice; i++){
         datamatrix[i] = new Array();
         assigned[i] = new Array();
       }
-      
+
       // Add the bottom-right corner if needed
       if ( ((rowsLengthMatrice * colsLengthMatrice) % 8) == 4) {
         datamatrix[rowsLengthMatrice-2][colsLengthMatrice-2] = 1;
@@ -897,13 +897,13 @@ var Barcode = {
         assigned[rowsLengthMatrice-1][colsLengthMatrice-2] = 1;
         assigned[rowsLengthMatrice-2][colsLengthMatrice-1] = 1;
       }
-      
+
       // Put the codewords into the matrix
       this.next(0,rowsLengthMatrice,colsLengthMatrice, codeWordsBits, datamatrix, assigned);
-      
+
       // Add the finder pattern
       datamatrix = this.addFinderPattern(datamatrix, rowsRegion, colsRegion, rowsRegionCW, colsRegionCW);
-      
+
       return datamatrix;
     }
   },
@@ -918,7 +918,7 @@ var Barcode = {
       }
       return le;
     },
-    // return a byte string from rgb values 
+    // return a byte string from rgb values
     cRgb: function(r,g,b){
       return String.fromCharCode(b) + String.fromCharCode(g) + String.fromCharCode(r);
     },
@@ -985,20 +985,20 @@ var Barcode = {
     var c1 = this.isHexColor(settings.color) ? this.lec.cHexColor(settings.color) : this.lec.cRgb(0,0,0);
     var bar0 = '';
     var bar1 = '';
-      
-    // create one bar 0 and 1 of "mw" byte length 
+
+    // create one bar 0 and 1 of "mw" byte length
     for(i=0; i<mw; i++){
       bar0 += c0;
       bar1 += c1;
     }
     var bars = '';
-  
+
     var padding = (4 - ((mw * columns * 3) % 4)) % 4; // Padding for 4 byte alignment ("* 3" come from "3 byte to color R, G and B")
     var dataLen = (mw * columns + padding) * mh * lines;
-  
+
     var pad = '';
     for(i=0; i<padding; i++) pad += '\0';
-    
+
     // Bitmap header
     var bmp = 'BM' +                            // Magic Number
               this.lec.cInt(54 + dataLen, 4) +  // Size of Bitmap size (header size + data len)
@@ -1031,7 +1031,7 @@ var Barcode = {
     object.setAttribute('type', 'image/bmp');
     object.setAttribute('data', 'data:image/bmp;base64,'+ this.base64Encode(bmp));
     this.resize($container, mw * columns + padding).update(object);
-                    
+
   },
   // bmp 1D barcode renderer
   digitToBmp: function($container, settings, digit, hri){
@@ -1049,7 +1049,7 @@ var Barcode = {
     var lines = digit.length;
     var columns = digit[0].length;
     var content = "";
-    var bar0 = "<div style=\"float: left; font-size: 0px; background-color: " + settings.bgColor + "; height: " + mh + "px; width: &Wpx\"></div>";    
+    var bar0 = "<div style=\"float: left; font-size: 0px; background-color: " + settings.bgColor + "; height: " + mh + "px; width: &Wpx\"></div>";
     var bar1 = "<div style=\"float: left; font-size: 0px; width:0; border-left: &Wpx solid " + settings.color + "; height: " + mh + "px;\"></div>";
 
     var len, current;
@@ -1068,13 +1068,13 @@ var Barcode = {
       if (len > 0){
         content += (current == '0' ? bar0 : bar1).replace("&W", len * mw);
       }
-    }  
+    }
     if (settings.showHRI){
       content += "<div style=\"clear:both; width: 100%; background-color: " + settings.bgColor + "; color: " + settings.color + "; text-align: center; font-size: " + settings.fontSize + "px; margin-top: " + settings.marginHRI + "px;\">"+hri+"</div>";
     }
     this.resize($container, mw * columns).update(content);
   },
-  // css 1D barcode renderer  
+  // css 1D barcode renderer
   digitToCss: function($container, settings, digit, hri){
     var w = Barcode.intval(settings.barWidth);
     var h = Barcode.intval(settings.barHeight);
@@ -1089,22 +1089,22 @@ var Barcode = {
   digitToSvgRenderer: function($container, settings, digit, hri, mw, mh){
     var lines = digit.length;
     var columns = digit[0].length;
-    
+
     var width = mw * columns;
     var height = mh * lines;
     if (settings.showHRI){
       var fontSize = Barcode.intval(settings.fontSize);
       height += Barcode.intval(settings.marginHRI) + fontSize;
     }
-    
+
     // svg header
     var svg = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="' + width + '" height="' + height + '">';
-    
+
     // background
     svg += '<rect width="' +  width + '" height="' + height + '" x="0" y="0" fill="' + settings.bgColor + '" />';
-    
+
     var bar1 = '<rect width="&W" height="' + mh + '" x="&X" y="&Y" fill="' + settings.color + '" />';
-    
+
     var len, current;
     for(var y=0; y<lines; y++){
       len = 0;
@@ -1124,7 +1124,7 @@ var Barcode = {
         svg += bar1.replace("&W", len * mw).replace("&X", (columns - len) * mw).replace("&Y", y * mh);
       }
     }
-    
+
     if (settings.showHRI){
       svg += '<g transform="translate(' + Math.floor(width/2) + ' 0)">';
       svg += '<text y="' + (height - Math.floor(fontSize/2)) + '" text-anchor="middle" style="font-family: Arial; font-size: ' + fontSize + 'px;" fill="' + settings.color + '">' + hri + '</text>';
@@ -1132,7 +1132,7 @@ var Barcode = {
     }
     // svg footer
     svg += '</svg>';
-    
+
     // create a dom object, flush container and add object to the container
     var object = document.createElement('object');
     object.setAttribute('type', 'image/svg+xml');
@@ -1150,23 +1150,23 @@ var Barcode = {
     var s = Barcode.intval(settings.moduleSize);
     this.digitToSvgRenderer($container, settings, digit, hri, s, s);
   },
-  
+
   // canvas barcode renderer
   digitToCanvasRenderer : function($container, settings, digit, hri, xi, yi, mw, mh){
     var canvas = $container;
     if ( !canvas || !canvas.getContext ) return; // not compatible
-    
+
     var lines = digit.length;
     var columns = digit[0].length;
-    
+
     var ctx = canvas.getContext('2d');
     ctx.lineWidth = 1;
     ctx.lineCap = 'butt';
     ctx.fillStyle = settings.bgColor;
     ctx.fillRect (xi, yi, columns * mw, lines * mh);
-    
+
     ctx.fillStyle = settings.color;
-    
+
     for(var y=0; y<lines; y++){
       var len = 0;
       var current = digit[y][0];
@@ -1217,7 +1217,7 @@ var barcodeMethod = {
         crc   = true,
         rect  = false,
         b2d   = false;
-    
+
     if (typeof(datas) == "string"){
       code = datas;
     } else if (typeof(datas) == "object"){
@@ -1226,12 +1226,12 @@ var barcodeMethod = {
       rect = typeof(datas.rect) != "undefined" ? datas.rect : false;
     }
     if (code == "") return(false);
-    
+
     if (typeof(settings) == "undefined") settings = [];
     for(var name in Barcode.settings){
       if (settings[name] == undefined) settings[name] = Barcode.settings[name];
     }
-    
+
     switch(type){
       case "std25":
       case "int25":
@@ -1271,22 +1271,22 @@ var barcodeMethod = {
         digit = Barcode.msi.getDigit(code, crc);
         hri = Barcode.msi.compute(code, crc);
       break;
-      case "datamatrix":   
+      case "datamatrix":
         digit = Barcode.datamatrix.getDigit(code, rect);
         hri = code;
         b2d = true;
-      break; 
+      break;
     }
     if (digit.length == 0) return($this);
-    
+
     // Quiet Zone
     if ( !b2d && settings.addQuietZone) digit = "0000000000" + digit + "0000000000";
-    
+
     var fname = 'digitTo' + settings.output.charAt(0).toUpperCase() + settings.output.substr(1) + (b2d ? '2D' : '');
     if (typeof(Barcode[fname]) == 'function') {
       Barcode[fname]($this, settings, digit, hri);
     }
-    
+
     return($this);
   }
 };

--- a/prototype/prototype-barcode.js
+++ b/prototype/prototype-barcode.js
@@ -976,6 +976,11 @@ var Barcode = {
     $container.update('');
     return $container;
   },
+  // apply antialiasing for CSS rendering only
+  antialiasing: function($container){
+    $container.style.cssText += 'display: flex;flex-flow: row wrap;justify-content: space-around;';
+    return $container;
+  },
   // bmp barcode renderer
   digitToBmpRenderer: function($container, settings, digit, hri, mw, mh){
     var lines = digit.length;
@@ -1072,6 +1077,7 @@ var Barcode = {
     if (settings.showHRI){
       content += "<div style=\"clear:both; width: 100%; background-color: " + settings.bgColor + "; color: " + settings.color + "; text-align: center; font-size: " + settings.fontSize + "px; margin-top: " + settings.marginHRI + "px;\">"+hri+"</div>";
     }
+    this.antialiasing($container);
     this.resize($container, mw * columns).update(content);
   },
   // css 1D barcode renderer
@@ -1098,7 +1104,7 @@ var Barcode = {
     }
 
     // svg header
-    var svg = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="' + width + '" height="' + height + '">';
+    var svg = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="' + width + '" height="' + height + '" shape-rendering="crispEdges">';
 
     // background
     svg += '<rect width="' +  width + '" height="' + height + '" x="0" y="0" fill="' + settings.bgColor + '" />';


### PR DESCRIPTION
From issue #25 : https://github.com/jbdemonte/barcode/issues/25

Unreadable datamatrix when zooming in or out can occur in SVG and CSS rendering.

This issue is due to the browser that is doing antialiasing and not due to the Barcode algorithms.

I fixed both jQuery and Prototype codes. For both, I fixed the CSS renderer and the SVG renderer.

To prevent from this issue:
- In the SVG renderer I simply set the shape rendering to crisp edges;
- However in the CSS renderer the trick to set the  image rendering to crisp edges didn't work. I then added CSS properties to the container to be flex (row with wrapping) and specified the browser to distribute space between and around content items in a "space-around" manner.

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering
https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering