### PR TITLE
The bitmap data size set in the bitmap header was incorrect.

### DIFF
--- a/jquery/jquery-barcode.js
+++ b/jquery/jquery-barcode.js
@@ -1204,7 +1204,7 @@
     }
 
     padding = (4 - ((mw * columns * 3) % 4)) % 4; // Padding for 4 byte alignment ("* 3" come from "3 byte to color R, G and B")
-    dataLen = (mw * columns + padding) * mh * lines;
+    dataLen = ((mw * columns * 3) + padding) * mh * lines;
 
     for (i = 0; i < padding; i++) {
       pad += '\0';


### PR DESCRIPTION
Fixes #30 
The data length calculation for the bitmap header did not take into account that we have 3 channels (RGB).
I simply added the * 3 like we already do in the padding calculation.